### PR TITLE
fix: gtin support in jsonld

### DIFF
--- a/src/steps/render-jsonld.js
+++ b/src/steps/render-jsonld.js
@@ -27,6 +27,7 @@ function renderOffer(state, variant, simple = false) {
     url,
     options,
     custom,
+    gtin,
   } = variant;
 
   const resolvedImages = Array.isArray(images)
@@ -56,6 +57,7 @@ function renderOffer(state, variant, simple = false) {
     ...(price?.final && { price: price.final }),
     ...(availability && { availability: `https://schema.org/${availability}` }),
     ...(itemCondition && { itemCondition: `https://schema.org/${itemCondition}` }),
+    ...(gtin && { gtin }),
     ...(url && { url }),
     ...(options && { options }),
     ...(priceSpecification && { priceSpecification }),
@@ -75,6 +77,7 @@ function convertToJsonLD(state, product) {
     images = [],
     variants = [],
     custom,
+    gtin,
   } = product;
 
   const jsonld = {
@@ -83,6 +86,7 @@ function convertToJsonLD(state, product) {
     ...(sku && { sku }),
     ...(name || metaTitle ? { name: name || metaTitle } : {}),
     ...(metaDescription || description ? { description: metaDescription || stripHTML(description).trim() } : {}),
+    ...(gtin && { gtin }),
     ...(url && { url }),
     ...(brand && { brand: { '@type': 'Brand', name: brand } }),
   };

--- a/test/fixtures/product/product-bundle.html
+++ b/test/fixtures/product/product-bundle.html
@@ -24,6 +24,7 @@
       "sku": "BBND5000LB",
       "name": "BlitzMax 5000 Bundle",
       "description": "The BlitzMax 5000 Bundle combines our most popular blender with essential accessories. Includes Personal Cup Adapter, spatula, and tamper holder.",
+      "gtin": "1234567890123",
       "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
       "brand": {
         "@type": "Brand",
@@ -51,6 +52,7 @@
           "price": "449.95",
           "availability": "https://schema.org/InStock",
           "itemCondition": "https://schema.org/NewCondition",
+          "gtin": "1234567890333",
           "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
           "options": [
             {
@@ -77,6 +79,7 @@
           "price": "449.95",
           "availability": "https://schema.org/InStock",
           "itemCondition": "https://schema.org/NewCondition",
+          "gtin": "1234567890444",
           "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
           "options": [
             {
@@ -103,6 +106,7 @@
           "price": "449.95",
           "availability": "https://schema.org/InStock",
           "itemCondition": "https://schema.org/NewCondition",
+          "gtin": "1234567890555",
           "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
           "options": [
             {

--- a/test/fixtures/product/product-bundle.json
+++ b/test/fixtures/product/product-bundle.json
@@ -6,6 +6,7 @@
   "type": "bundle",
   "metaTitle": "BlitzMax 5000 Bundle",
   "metaDescription": "The BlitzMax 5000 Bundle combines our most popular blender with essential accessories. Includes Personal Cup Adapter, spatula, and tamper holder.",
+  "gtin": "1234567890123",
   "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
   "images": [
     {
@@ -126,6 +127,7 @@
         "regular": "499.95",
         "final": "449.95"
       },
+      "gtin": "1234567890333",
       "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
       "images": [
         {
@@ -151,6 +153,7 @@
         "final": "449.95"
       },
       "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
+      "gtin": "1234567890444",
       "images": [
         {
           "url": "./blitzmax-5000-bundle-white.png"
@@ -174,6 +177,7 @@
         "regular": "499.95",
         "final": "449.95"
       },
+      "gtin": "1234567890555",
       "url": "https://www.blendify.com/us/en_us/products/blitzmax-5000-bundle",
       "images": [
         {

--- a/test/fixtures/product/product-configurable.html
+++ b/test/fixtures/product/product-configurable.html
@@ -24,6 +24,7 @@
       "sku": "BlitzMax 5000",
       "name": "BlitzMax 5000",
       "description": "The BlitzMax 5000 is the ultimate blending powerhouse from Blendify. It combines high performance with a sleek design, making it ideal for smoothies, soups, and more.",
+      "gtin": "1234567890123",
       "url": "https://www.blendify.com/us/en_us/shop/blitzmax-5000",
       "brand": {
         "@type": "Brand",
@@ -48,6 +49,7 @@
           "price": "349.95",
           "availability": "https://schema.org/InStock",
           "itemCondition": "https://schema.org/NewCondition",
+          "gtin": "1234567890333",
           "url": "https://www.blendify.com/shop/blitzmax-5000",
           "options": [
             {
@@ -86,6 +88,7 @@
           "price": "399.95",
           "availability": "https://schema.org/InStock",
           "itemCondition": "https://schema.org/NewCondition",
+          "gtin": "1234567890444",
           "url": "https://www.blendify.com/shop/blitzmax-5000",
           "options": [
             {

--- a/test/fixtures/product/product-configurable.json
+++ b/test/fixtures/product/product-configurable.json
@@ -16,6 +16,7 @@
   ],
   "brand": "Blendify",
   "availability": "InStock",
+  "gtin": "1234567890123",
   "price": {
     "currency": "USD",
     "regular": "399.95",
@@ -64,6 +65,7 @@
         "regular": "399.95",
         "final": "349.95"
       },
+      "gtin": "1234567890333",
       "url": "https://www.blendify.com/shop/blitzmax-5000",
       "images": [
         { "url": "./blitzmax-5000-black-1.png" },
@@ -94,6 +96,7 @@
         "regular": "399.95",
         "final": "399.95"
       },
+      "gtin": "1234567890444",
       "url": "https://www.blendify.com/shop/blitzmax-5000",
       "images": [
         { "url": "./blitzmax-5000-silver-1.png" },

--- a/test/fixtures/product/product-simple.html
+++ b/test/fixtures/product/product-simple.html
@@ -24,6 +24,7 @@
       "sku": "BlitzMax 5000",
       "name": "BlitzMax 5000",
       "description": "The BlitzMax 5000 is the ultimate blending powerhouse from Blendify. It combines high performance with a sleek design, making it ideal for smoothies, soups, and more.",
+      "gtin": "1234567890123",
       "url": "https://www.blendify.com/us/en_us/shop/blitzmax-5000",
       "brand": {
         "@type": "Brand",
@@ -47,6 +48,7 @@
           "priceCurrency": "USD",
           "price": "349.95",
           "availability": "https://schema.org/InStock",
+          "gtin": "1234567890123",
           "url": "https://www.blendify.com/us/en_us/shop/blitzmax-5000",
           "priceSpecification": {
             "@type": "UnitPriceSpecification",

--- a/test/fixtures/product/product-simple.json
+++ b/test/fixtures/product/product-simple.json
@@ -7,6 +7,7 @@
   "title": "Blendify BlitzMax 5000",
   "metaTitle": "Blendify BlitzMax 5000 Blender",
   "metaDescription": "The BlitzMax 5000 is the ultimate blending powerhouse from Blendify. It combines high performance with a sleek design, making it ideal for smoothies, soups, and more.",
+  "gtin": "1234567890123",
   "url": "https://www.blendify.com/us/en_us/shop/blitzmax-5000",
   "images": [
     { "url": "./blitzmax-5000-1.png" },


### PR DESCRIPTION
Support gtin at the parent and variant level. Uses generalized `gtin` property. No support for `gtin12`, `gtin13` etc.

https://schema.org/Product