### PR TITLE
fix: render options as data attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@adobe/helix-html-pipeline": "6.25.2",
         "@adobe/helix-shared-utils": "3.0.2",
         "@dylandepass/helix-product-shared": "1.2.1",
+        "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-select": "6.0.4",
         "hast-util-to-html": "9.0.5",
@@ -3986,7 +3987,8 @@
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.4.5",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@adobe/helix-html-pipeline": "6.25.2",
     "@adobe/helix-shared-utils": "3.0.2",
     "@dylandepass/helix-product-shared": "1.2.1",
+    "github-slugger": "2.0.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-select": "6.0.4",
     "hast-util-to-html": "9.0.5",

--- a/test/fixtures/product/custom-metadata.html
+++ b/test/fixtures/product/custom-metadata.html
@@ -178,7 +178,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -197,19 +197,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -228,17 +217,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/image-props.html
+++ b/test/fixtures/product/image-props.html
@@ -175,7 +175,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -194,19 +194,8 @@
             <img loading="lazy" alt="BlitzMax 5000 - Midnight Black" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium" height="200">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -225,17 +214,6 @@
             <img loading="lazy" alt="BlitzMax 5000 - Silver Steel" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium" height="200">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-html-description.html
+++ b/test/fixtures/product/no-html-description.html
@@ -175,7 +175,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -194,19 +194,8 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -225,17 +214,6 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-images.html
+++ b/test/fixtures/product/no-images.html
@@ -129,35 +129,13 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-meta-title.html
+++ b/test/fixtures/product/no-meta-title.html
@@ -187,7 +187,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$399.95</p>
         <p>
@@ -206,19 +206,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -237,17 +226,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-metadescription-no-description.html
+++ b/test/fixtures/product/no-metadescription-no-description.html
@@ -200,7 +200,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -219,19 +219,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&amp;format=png&amp;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -250,17 +239,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-metadescription-with-html-description.html
+++ b/test/fixtures/product/no-metadescription-with-html-description.html
@@ -177,7 +177,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -196,19 +196,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -227,17 +216,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-name-no-metatitle.html
+++ b/test/fixtures/product/no-name-no-metatitle.html
@@ -192,7 +192,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -211,19 +211,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -242,17 +231,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-option-uid.html
+++ b/test/fixtures/product/no-option-uid.html
@@ -190,7 +190,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -209,18 +209,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -239,17 +229,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-price.html
+++ b/test/fixtures/product/no-price.html
@@ -182,7 +182,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>
           <picture>
@@ -200,19 +200,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>
           <picture>
@@ -230,17 +219,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-product-content-html-description.html
+++ b/test/fixtures/product/no-product-content-html-description.html
@@ -193,7 +193,7 @@
           <li>Recipe Guide</li>
         </ul>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -212,19 +212,8 @@
             <img loading="lazy" alt="" src="./media_f6789012345678901234567890abcdef01234567.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -243,17 +232,6 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-product-content-text-description.html
+++ b/test/fixtures/product/no-product-content-text-description.html
@@ -173,7 +173,7 @@
       <div>
         <p>The BlitzMax 5000 is the ultimate blending powerhouse. Its sleek design and powerful motor make it perfect for creating smoothies, soups, and more. Equipped with advanced blending programs and a 64-ounce container, it is engineered to tackle any blending task effortlessly.</p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -192,19 +192,8 @@
             <img loading="lazy" alt="" src="./media_f6789012345678901234567890abcdef01234567.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -223,17 +212,6 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/no-specifications-no-name.html
+++ b/test/fixtures/product/no-specifications-no-name.html
@@ -193,7 +193,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -212,19 +212,8 @@
             <img loading="lazy" alt="" src="./media_b2c3d4e5f6789012345678901234567890abcdef.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -243,17 +232,6 @@
             <img loading="lazy" alt="" src="./media_c3d4e5f6789012345678901234567890abcdef01.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/non-mediabus-images.html
+++ b/test/fixtures/product/non-mediabus-images.html
@@ -138,7 +138,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -151,17 +151,6 @@
             <img loading="lazy" alt="" src="https://www.commercesite.com/media/catalog/product/c/s/cs-rglam-black_1.png">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/product-bundle.html
+++ b/test/fixtures/product/product-bundle.html
@@ -276,7 +276,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK-BND" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000-bundle---midnight-black">BlitzMax 5000 Bundle - Midnight Black</h2>
         <p>$449.95 (<del>$499.95</del>)</p>
         <p>
@@ -287,19 +287,8 @@
             <img loading="lazy" alt="" src="./media_0789012345678901234567890abcdef012345678.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK-BND</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL-BND" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000-bundle---silver-steel">BlitzMax 5000 Bundle - Silver Steel</h2>
         <p>$449.95 (<del>$499.95</del>)</p>
         <p>
@@ -310,19 +299,8 @@
             <img loading="lazy" alt="" src="./media_2901234567890123456789abcdef0123456789ac.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL-BND</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-RED-BND" data-color="Crimson Red" data-uid="Y29uZmlndXJhYmxlLzkzLzUz">
         <h2 id="blitzmax-5000-bundle---crimson-red">BlitzMax 5000 Bundle - Crimson Red</h2>
         <p>$449.95 (<del>$499.95</del>)</p>
         <p>
@@ -333,17 +311,6 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-RED-BND</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Crimson Red</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUz</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/product-configurable.html
+++ b/test/fixtures/product/product-configurable.html
@@ -196,7 +196,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK" data-color="Midnight Black" data-uid="Y29uZmlndXJhYmxlLzkzLzQz">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -215,19 +215,8 @@
             <img loading="lazy" alt="" src="./media_f6789012345678901234567890abcdef01234567.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-BLK</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Midnight Black</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzQz</div>
-          </div>
-        </div>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL" data-color="Silver Steel" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>
@@ -246,17 +235,6 @@
             <img loading="lazy" alt="" src="./media_1890123456789012345678abcdef0123456789ab.png?width=750&#x26;format=png&#x26;optimize=medium">
           </picture>
         </p>
-        <div class="section-metadata">
-          <div>
-            <div>sku</div>
-            <div>5000-SIL</div>
-          </div>
-          <div>
-            <div>color</div>
-            <div>Silver Steel</div>
-            <div>Y29uZmlndXJhYmxlLzkzLzUy</div>
-          </div>
-        </div>
       </div>
     </main>
     <footer></footer>

--- a/test/fixtures/product/variants-no-options.html
+++ b/test/fixtures/product/variants-no-options.html
@@ -177,7 +177,7 @@
         <h3 id="year-full-warranty-1"><strong>10-Year Full Warranty</strong></h3>
         <p>We stand behind the quality of our machines with full warranties, covering parts, performance, labor, and two-way shipping at no cost to you.<a href="https://www.commercesite.com/us/en_us/shop/10-year-warranty/"> Read the Warranty.</a></p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-BLK">
         <h2 id="blitzmax-5000---midnight-black">BlitzMax 5000 - Midnight Black</h2>
         <p>$349.95 (<del>$399.95</del>)</p>
         <p>
@@ -197,7 +197,7 @@
           </picture>
         </p>
       </div>
-      <div class="variant">
+      <div class="section" data-sku="5000-SIL">
         <h2 id="blitzmax-5000---silver-steel">BlitzMax 5000 - Silver Steel</h2>
         <p>$399.95</p>
         <p>


### PR DESCRIPTION
- Render variant options as data attributes and not  in section metadata
`<div class="section" data-sku="abc" data-color="silver" data-uid="Y29uZmlndXJhYmxlLzkzLzUy">`

- If no authored content and no description don't render an empty section with an empty `p`