### PR TITLE
fix: use label instead of alt for image tags

### DIFF
--- a/src/steps/render-body.js
+++ b/src/steps/render-body.js
@@ -34,14 +34,14 @@ export function formatPrice(price) {
 
 // Render media. Image first than anchor if video
 function renderMedia(media) {
-  const { url, alt, title } = media;
+  const { url, label, title } = media;
   if (media.video) {
     return h('p', [
-      createOptimizedPicture(url, alt, title),
+      createOptimizedPicture(url, label, title),
       h('a', { href: media.video }, 'Video'),
     ]);
   }
-  return h('p', createOptimizedPicture(url, alt, title));
+  return h('p', createOptimizedPicture(url, label, title));
 }
 
 /**
@@ -171,7 +171,7 @@ export default async function render(state, req, res) {
     main.children.push(...variants.map((variant) => h('div', { className: 'section', ...variantDataAttrs(variant) }, [
       h('h2', variant.name),
       formatPrice(variant.price),
-      ...(variant.images?.length > 0 ? variant.images.map((img) => h('p', createOptimizedPicture(img.url, img.alt, img.title))) : []),
+      ...(variant.images?.length > 0 ? variant.images.map((img) => h('p', createOptimizedPicture(img.url, img.label, img.title))) : []),
     ])));
   }
 

--- a/test/fixtures/product/image-props.json
+++ b/test/fixtures/product/image-props.json
@@ -10,16 +10,16 @@
   "images": [
     { 
       "url": "./media_a1b2c3d4e5f6789012345678901234567890abcd.png#height=200",
-      "alt": "BlitzMax 5000",
+      "label": "BlitzMax 5000",
       "title": "BlitzMax 5000 is Amazing"
     },
     { 
       "url": "./media_b2c3d4e5f6789012345678901234567890abcdef.png#height=200",
-      "alt": "BlitzMax 5000 Top View"
+      "label": "BlitzMax 5000 Top View"
     },
     { 
       "url": "./media_c3d4e5f6789012345678901234567890abcdef01.png#height=200",
-      "alt": "BlitzMax 5000 Bottom View"
+      "label": "BlitzMax 5000 Bottom View"
     },
     { "url": "./media_d4e5f6789012345678901234567890abcdef012.png", "video": "https://www.youtube.com/watch?v=123456" }
   ],
@@ -76,11 +76,11 @@
       "images": [
         { 
           "url": "./media_a1b2c3d4e5f6789012345678901234567890abcd.png#height=200",
-          "alt": "BlitzMax 5000 - Midnight Black"
+          "label": "BlitzMax 5000 - Midnight Black"
         },
         { 
           "url": "./media_b2c3d4e5f6789012345678901234567890abcdef.png#height=200",
-          "alt": "BlitzMax 5000 - Midnight Black"
+          "label": "BlitzMax 5000 - Midnight Black"
         }
       ],
       "availability": "InStock",
@@ -105,12 +105,12 @@
       "images": [
         { 
           "url": "./media_b2c3d4e5f6789012345678901234567890abcdef.png#height=200",
-          "alt": "BlitzMax 5000 - Silver Steel",
+          "label": "BlitzMax 5000 - Silver Steel",
           "title": "BlitzMax 5000 - Silver Steel is Amazing"
         },
         { 
           "url": "./media_c3d4e5f6789012345678901234567890abcdef01.png#height=200",
-          "alt": "BlitzMax 5000 - Silver Steel",
+          "label": "BlitzMax 5000 - Silver Steel",
           "title": "BlitzMax 5000 - Silver Steel"
         }
       ],


### PR DESCRIPTION
Fix image alt text rendering by reading the label property from product data instead of alt, aligning the pipeline with the Product Bus schema contract. Update test fixture to match.
