### PR TITLE
fix: dedupe head meta tags, prefer authored over PB-generated (#86)

### DIFF
--- a/src/steps/render-head.js
+++ b/src/steps/render-head.js
@@ -62,7 +62,10 @@ export default async function render(state) {
     head.children.push(h('meta', { name: 'type', content: type }));
   }
 
-  // Add product metadata to the head
+  // Add product metadata to the head.
+  // Authored metadata takes precedence over PB-generated values: if a meta
+  // tag with the same name was already emitted above, replace its content
+  // instead of emitting a duplicate.
   if (metadata) {
     Object.entries(metadata).forEach(([key, value]) => {
       if (key.toLowerCase().startsWith(HREFLANG_PREFIX)) {
@@ -73,7 +76,17 @@ export default async function render(state) {
         }
         return;
       }
-      head.children.push(h('meta', { name: key, content: value }));
+
+      const existing = head.children.find(
+        (child) => child.type === 'element'
+          && child.tagName === 'meta'
+          && child.properties?.name === key,
+      );
+      if (existing) {
+        existing.properties.content = value;
+      } else {
+        head.children.push(h('meta', { name: key, content: value }));
+      }
     });
   }
 

--- a/test/fixtures/product/product-with-authored-metadata-content.html
+++ b/test/fixtures/product/product-with-authored-metadata-content.html
@@ -8,6 +8,7 @@
     <meta property="og:image" content="./media_testimage123.png?width=750&amp;format=png&amp;optimize=medium">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Test Product Page">
+    <meta name="description" content="Authored description that should win.">
     <meta name="robots" content="noindex, nofollow">
     <meta name="author" content="Test Author">
     <meta name="keywords" content="test, product, metadata">

--- a/test/product-html-pipe.test.js
+++ b/test/product-html-pipe.test.js
@@ -681,6 +681,18 @@ describe('Product HTML Pipe Test', () => {
       'Should have og:title from product data, not authored content',
     );
 
+    // Verify exactly one description meta tag is rendered, and authored wins
+    const descriptionMatches = resp.body.match(/<meta name="description"/g) || [];
+    assert.strictEqual(
+      descriptionMatches.length,
+      1,
+      'Should render exactly one description meta tag',
+    );
+    assert.ok(
+      resp.body.includes('<meta name="description" content="Authored description that should win.">'),
+      'Authored description should take precedence over PB-generated description',
+    );
+
     // Verify authored main content is included
     assert.ok(
       resp.body.includes('Product Details'),


### PR DESCRIPTION
render-head emitted a hardcoded `meta name="description"` and then re-emitted any authored description from `data.metadata`, producing two tags. Now a matching meta name is overridden in place so exactly one renders, with authored values taking precedence over PB-generated ones.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

Fixes #86

Thanks for contributing!